### PR TITLE
removing unnecessary requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,2 @@
-Flask==0.10.1
-Flask-SQLAlchemy==1.0
-Jinja2==2.7.3
-MarkupSafe==0.23
-SQLAlchemy==0.9.6
-Werkzeug==0.9.6
 beautifulsoup4==4.3.2
-itsdangerous==0.24
-psycopg2==2.5.3
-wsgiref==0.1.2
 scrapelib


### PR DESCRIPTION
Installation is very bloated by a lot of heavy requirements -- psycopg2 for Postgres, plus Flask and its attendant ORM (sqlalchemy.)  It looks like all that really gets used in `do.py` is beautifulsoup and scrapelib, so that's all we should make our target machines install.
